### PR TITLE
Resolve compile error on Mac if --enable-stream_missing used

### DIFF
--- a/Source/ZenLib/Ztring.cpp
+++ b/Source/ZenLib/Ztring.cpp
@@ -156,7 +156,9 @@ Ztring EmptyZtring;
 
 //---------------------------------------------------------------------------
 #if defined(STREAM_MISSING)
-    #if defined (_UNICODE)
+    #if defined (MACOS) || defined (MACOSX)
+        #define _tnprintf swprintf
+    #elif defined (_UNICODE)
         #define _tnprintf snwprintf
     #else
         #define _tnprintf snprintf


### PR DESCRIPTION
I was playing with configure parameters on MediaInfoLib and ZenLib to do some tests and found that correct version of unicode snprintf() on Mac is swprintf() .