### PR TITLE
Fix Crash

### DIFF
--- a/Source/ZenLib/MemoryDebug.cpp
+++ b/Source/ZenLib/MemoryDebug.cpp
@@ -35,6 +35,7 @@ using namespace std;
 namespace ZenLib
 {
 
+bool MemoryDebug::g_IsShutdown = false;
 //***************************************************************************
 // Constructors/destructor
 //***************************************************************************
@@ -47,6 +48,7 @@ MemoryDebug::~MemoryDebug()
 {
     if (!m_Blocks.empty())
         ReportLeaks();
+    g_IsShutdown = true;
 }
 
 //***************************************************************************

--- a/Source/ZenLib/MemoryDebug.h
+++ b/Source/ZenLib/MemoryDebug.h
@@ -40,7 +40,7 @@ class MemoryDebug
 public :
     ~MemoryDebug();
     static MemoryDebug& Instance();
-
+    static bool g_IsShutdown;
     void* Allocate(std::size_t Size, const char* File, int Line, bool Array);
     void  Free(void* Ptr, bool Array);
     void  NextDelete(const char*, int Line); //Sauvegarde les infos sur la désallocation courante
@@ -79,12 +79,18 @@ inline void* operator new[](std::size_t Size, const char* File, int Line)
 
 inline void operator delete(void* Ptr)
 {
-    ZenLib::MemoryDebug::Instance().Free(Ptr, false);
+    if (ZenLib::MemoryDebug::g_IsShutdown)
+        free(Ptr);
+    else
+        ZenLib::MemoryDebug::Instance().Free(Ptr, false);
 }
 
 inline void operator delete[](void* Ptr)
 {
-    ZenLib::MemoryDebug::Instance().Free(Ptr, true);
+    if (ZenLib::MemoryDebug::g_IsShutdown)
+        free(Ptr);
+    else
+        ZenLib::MemoryDebug::Instance().Free(Ptr, true);
 }
 
 #if !defined(__BORLANDC__) // Borland does not support overloaded delete


### PR DESCRIPTION
Ignore call inline void operator delete after MemoryDebug::~MemoryDebug()
Crash:
Fix Unhandled exception thrown: read access violation.
std::_Tree_comp_alloc<std::_Tmap_traits<void *,ZenLib::MemoryDebug::TBlock,std::less<void *>,std::allocator<std::pair<void * const,ZenLib::MemoryDebug::TBlock> >,0> >::_Isnil(...) returned 0xDDDDDDEA.
If there is a handler for this exception, the program may be safely continued.