### PR TITLE
CMake: fix SIZE_T_IS_LONG configuring

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -105,8 +105,10 @@ else()
   set(ZenLib_Unicode "no")
 endif()
 
-try_compile(SIZE_T_IS_NOT_LONG ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/size_t_is_long_check.cpp)
-if(NOT SIZE_T_IS_NOT_LONG)
+include(CheckTypeSize)
+check_type_size(size_t SIZE_T_SIZE)
+check_type_size(long LONG_SIZE)
+if(SIZE_T_SIZE EQUAL LONG_SIZE)
   target_compile_definitions(zen PUBLIC SIZE_T_IS_LONG)
 endif()
 

--- a/Project/CMake/size_t_is_long_check.cpp
+++ b/Project/CMake/size_t_is_long_check.cpp
@@ -1,9 +1,0 @@
-#include <cstdlib>
-void foo(signed int) {}
-void foo(unsigned int) {}
-
-int main ()
-{
-    foo(size_t(0));
-    return 0;
-}


### PR DESCRIPTION
MSYS2 & MinGW64 fails under Windows:

```
$ cmake --build .
-- Configuring done
-- Generating done
-- Build files have been written to: C:/msys64/home/user/projects/ZenLib/Project/CMake/build
Scanning dependencies of target zen
[  4%] Building CXX object CMakeFiles/zen.dir/C_/msys64/home/user/projects/ZenLib/Source/ZenLib/Conf.cpp.obj
[  8%] Building CXX object CMakeFiles/zen.dir/C_/msys64/home/user/projects/ZenLib/Source/ZenLib/CriticalSection.cpp.obj
[ 12%] Building CXX object CMakeFiles/zen.dir/C_/msys64/home/user/projects/ZenLib/Source/ZenLib/Dir.cpp.obj
In file included from C:/msys64/home/user/projects/ZenLib/Source/ZenLib/ZtringList.h:19:0,
                 from C:/msys64/home/user/projects/ZenLib/Source/ZenLib/Dir.h:19,
                 from C:/msys64/home/user/projects/ZenLib/Source/ZenLib/Dir.cpp:39:
C:/msys64/home/user/projects/ZenLib/Source/ZenLib/Ztring.h:187:13: error: 'ZenLib::Ztring& ZenLib::Ztring::From_Number(size_t, ZenLib::int8u)' cannot be overloaded
     Ztring& From_Number  (const size_t,   int8u Radix=10);
             ^~~~~~~~~~~
C:/msys64/home/user/projects/ZenLib/Source/ZenLib/Ztring.h:176:13: error: with 'ZenLib::Ztring& ZenLib::Ztring::From_Number(ZenLib::int64u, ZenLib::int8u)'
     Ztring& From_Number  (const int64u,   int8u Radix=10);
             ^~~~~~~~~~~
C:/msys64/home/user/projects/ZenLib/Source/ZenLib/Ztring.h:316:19: error: 'static ZenLib::Ztring ZenLib::Ztring::ToZtring(size_t, ZenLib::int8u)' cannot be overloaded
     static Ztring ToZtring  (const size_t   I,  int8u Radix=10)                  {return Ztring().From_Number(I, Radix);};
                   ^~~~~~~~
C:/msys64/home/user/projects/ZenLib/Source/ZenLib/Ztring.h:310:19: error: with 'static ZenLib::Ztring ZenLib::Ztring::ToZtring(ZenLib::int64u, ZenLib::int8u)'
     static Ztring ToZtring  (const int64u   I, int8u Radix=10)                   {return Ztring().From_Number(I, Radix);};
                   ^~~~~~~~
make[2]: *** [CMakeFiles/zen.dir/build.make:111: CMakeFiles/zen.dir/C_/msys64/home/user/projects/ZenLib/Source/ZenLib/Dir.cpp.obj] Ошибка 1
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/zen.dir/all] Ошибка 2
make: *** [Makefile:128: all] Ошибка 2
```

The reason is incorrectly defined `SIZE_T_IS_LONG`, caused by broken `size_t_is_long_check.cpp` test.

Now CMake will use standard [`check_type_size`](https://cmake.org/cmake/help/v2.8.11/cmake.html#module:CheckTypeSize) macro to detect sizes of `size_t` and `long`. then sizes are compared and `SIZE_T_IS_LONG` is defined when required.