### PR TITLE
CMake: don't define SIZE_T_IS_LONG when long is 32-bit

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 include(CheckTypeSize)
 check_type_size(size_t SIZE_T_SIZE)
 check_type_size(long LONG_SIZE)
-if(SIZE_T_SIZE EQUAL LONG_SIZE)
+if((LONG_SIZE GREATER 4) AND (SIZE_T_SIZE EQUAL LONG_SIZE))
   target_compile_definitions(zen PUBLIC SIZE_T_IS_LONG)
 endif()
 


### PR DESCRIPTION
This pull request is related to #38 

It fixes CMake configuring on platforms where `long` is <= 32-bit.

Tested under VS2015 (32-bit & 64-bit solution), where `long` is 32-bit and under Ubuntu 16.04 64-bit, where `long` is 64-bit.
