### PR TITLE
CMake > 2.8.12: fix warning

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -2,6 +2,9 @@ project(ZenLib)
 
 cmake_minimum_required(VERSION 2.8.11)
 
+# Allow use of the LOCATION target property with CMake version >= 2.8.12
+cmake_policy(SET CMP0026 OLD)
+
 if(WIN32)
   option(BUILD_SHARED_LIBS "Build shared libs" OFF)
 else()


### PR DESCRIPTION
This pull request sets [CMP0026](https://cmake.org/cmake/help/v3.0/policy/CMP0026.html) policy to `OLD` to supress warnings when configuring with CMake > 2.8.12:

```
CMake Warning (dev) at CMakeLists.txt:126 (get_target_property):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target "zen".  Use the target
  name directly with add_custom_command, or use the generator expression
  $<TARGET_FILE>, as appropriate.
```