### PR TITLE
Make template pkg-config file consistent between autotools and cmake

### DIFF
--- a/Project/CMake/libzen.pc.in
+++ b/Project/CMake/libzen.pc.in
@@ -3,10 +3,10 @@ exec_prefix=${prefix}
 libdir=@LIB_INSTALL_DIR@
 includedir=@INCLUDE_INSTALL_DIR@
 Unicode=@ZenLib_Unicode@
+Libs_Static=@LIB_INSTALL_DIR@/libzen.a -lpthread -lstdc++
 
 Name: libzen
 Version: @ZenLib_VERSION_STRING@
 Description: ZenLib
 Libs: -L${libdir} -lzen -lpthread -lstdc++
 Cflags: -I${includedir} @ZenLib_CXXFLAGS@
-Requires: zlib

--- a/Project/GNU/Library/libzen.pc.in
+++ b/Project/GNU/Library/libzen.pc.in
@@ -9,5 +9,5 @@ Libs_Static=@libdir@/libzen.a -lpthread
 Name: libzen
 Version: @PACKAGE_VERSION@
 Description: ZenLib
-Libs: -L@libdir@ -lzen -lpthread -lstdc++
+Libs: -L${libdir} -lzen -lpthread -lstdc++
 Cflags: -I${includedir} @ZenLib_CXXFLAGS@


### PR DESCRIPTION
The WstringMissing isn't selectable in CMake so it wasn't added.
Also, no idea why CMake build required zlib and autotools didn't.