### PR TITLE
Fix Http_Utils

### DIFF
--- a/Source/ZenLib/Format/Http/Http_Utils.cpp
+++ b/Source/ZenLib/Format/Http/Http_Utils.cpp
@@ -100,7 +100,6 @@ std::string URL_Encoded_Encode (const std::string& URL)
     {
         if ((URL[Pos]>='\x00' && URL[Pos]<='\x20')
          || URL[Pos]=='\x7F'
-         || URL[Pos]==' '
          || URL[Pos]=='<'
          || URL[Pos]=='>'
          || URL[Pos]=='#'
@@ -141,7 +140,6 @@ std::wstring URL_Encoded_Encode (const std::wstring& URL)
     {
         if (URL[Pos]<=L'\x20'
          || URL[Pos]==L'\x7F'
-         || URL[Pos]==L' '
          || URL[Pos]==L'<'
          || URL[Pos]==L'>'
          || URL[Pos]==L'#'


### PR DESCRIPTION
 V560 A part of conditional expression is always false: URL[Pos] == ' ' (URL[Pos]<='\x20')