### PR TITLE
CMake: Copy source files into binary dir

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -17,7 +17,13 @@ option(ENABLE_UNICODE "Enable unicode support" ON)
 option(LARGE_FILES "Enable large files support" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/Modules/")
-set(ZenLib_SOURCES_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../Source)
+if(MINGW)
+  # Work around for cmake generating extra long paths
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../Source DESTINATION .)
+  set(ZenLib_SOURCES_PATH ${CMAKE_CURRENT_BINARY_DIR}/Source)
+else()
+  set(ZenLib_SOURCES_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../Source)
+endif()
 
 # On Windows debug library should have 'd' postfix.
 if(WIN32)
@@ -104,6 +110,11 @@ set(ZenLib_SRCS
   ${ZenLib_SOURCES_PATH}/ZenLib/Format/Http/Http_Request.cpp
   ${ZenLib_SOURCES_PATH}/ZenLib/Format/Http/Http_Utils.cpp
   )
+
+if(WIN32)
+  set_source_files_properties(${ZenLib_SRCS} ${ZenLib_HDRS} ${ZenLib_format_html_HDRS} ${ZenLib_format_http_HDRS}
+    PROPERTIES GENERATED true)
+endif()
 
 add_library(zen ${ZenLib_SRCS} ${ZenLib_HDRS} ${ZenLib_format_html_HDRS} ${ZenLib_format_http_HDRS})
 if(ENABLE_UNICODE)


### PR DESCRIPTION
A work around for certain compilers not working on windows due to extra long paths (Something like `CMakeFiles/mediainfo.dir/D_/actions/_work/media-autobuild_suite/media-autobuild_suite/build/libmediainfo-git/Source/ThirdParty/aes-gladman/aes_modes.c.o` under `D:/actions/_work/media-autobuild_suite/media-autobuild_suite/build/libmediainfo-git/build`. Not necessarily this project, but it has the same issue)

Since it the source files aren't subdirectories, cmake uses absolute paths to the files when deciding the output name.