### PR TITLE
Ztring: some date conversion methods were not thread safe, update

### DIFF
--- a/Source/ZenLib/Ztring.cpp
+++ b/Source/ZenLib/Ztring.cpp
@@ -1309,7 +1309,7 @@ Ztring& Ztring::Date_From_Seconds_1970 (const int64s Value)
     #if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _BSD_SOURCE || _SVID_SOURCE || _POSIX_SOURCE
     struct tm Gmt_Temp;
     struct tm *Gmt=gmtime_r(&Time, &Gmt_Temp);
-    #elif defined(_WIN32)
+    #elif defined(_MSC_VER)
     struct tm Gmt_Temp;
     errno_t gmtime_s_Result=gmtime_s(&Gmt_Temp , &Time);
     struct tm* Gmt=gmtime_s_Result?NULL:&Gmt_Temp;
@@ -1349,7 +1349,7 @@ Ztring& Ztring::Date_From_Seconds_1970_Local (const int32u Value)
     #if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _BSD_SOURCE || _SVID_SOURCE || _POSIX_SOURCE
     struct tm Gmt_Temp;
     struct tm *Gmt=localtime_r(&Time, &Gmt_Temp);
-    #elif defined(_WIN32)
+    #elif defined(_MSC_VER)
     struct tm Gmt_Temp;
     errno_t localtime_s_Result=localtime_s(&Gmt_Temp , &Time);
     struct tm* Gmt=localtime_s_Result?NULL:&Gmt_Temp;


### PR DESCRIPTION
Fix https://github.com/MediaArea/ZenLib/pull/107 not compiling with old Borland C++