### PR TITLE
Zstring.h: fix doxygen parameter name

### DIFF
--- a/Source/ZenLib/Ztring.h
+++ b/Source/ZenLib/Ztring.h
@@ -342,7 +342,7 @@ public :
     Ztring SubString (const tstring &Begin, const tstring &End, size_type Pos=0, ztring_t Options=Ztring_Nothing) const;
         /// @brief replace a string by another one
         /// @param ToFind string to find
-        /// @param ToReplace string wich replace the string found
+        /// @param ReplaceBy string wich replace the string found
         /// @param Pos Position to begin to scan string
         /// @param Options Options for searching \n
         ///                Available : Ztring_CaseSensitive, Ztring_Recursive


### PR DESCRIPTION
`ToReplace` does not exist but `ReplaceBy` does.

--------

This is a really minor change but it was a bit annoying when compiling ZenLib. :-)
(clang can warn about documentation mismatches)  
Because this is just a comment change, it is probably not worth having me in GitHub's contributors list.

I wouldn't mind if  you close this PR and fix it yourself. 😃 

Thanks for keeping ZenLib up-to-date. Very much appreciated. 👍 