### PR TITLE
Ztring.cpp: fix implicit float-to-double conversion warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 *.zip
 __history
 bin
+Build/
 Debug
 Debug_Ansi
 Debug_Build

--- a/Source/ZenLib/Utils.cpp
+++ b/Source/ZenLib/Utils.cpp
@@ -982,7 +982,7 @@ int32s float32_int32s (float32 F, bool Rounded)
         return (int32s)F;
     //Rounded
     int I1=(int)F;
-    if (F-I1>=0.5)
+    if (F-I1>=0.5f)
         return I1+1;
     else
         return I1;
@@ -1001,7 +1001,7 @@ int64s float32_int64s (float32 F, bool Rounded)
         return (int64s)F;
     //Rounded
     int I1=(int)F;
-    if (F-I1>=0.5)
+    if (F-I1>=0.5f)
         return I1+1;
     else
         return I1;

--- a/Source/ZenLib/Ztring.cpp
+++ b/Source/ZenLib/Ztring.cpp
@@ -1855,7 +1855,7 @@ int8s Ztring::To_int8s (int8u Radix, ztring_t Options) const
     {
         float80 F=To_float80();
         F-=I;
-        if (F>=0.5)
+        if (F>=0.5f)
             return (int8s)I+1;
     }
 
@@ -1893,7 +1893,7 @@ int8u Ztring::To_int8u (int8u Radix, ztring_t Options) const
     {
         float32 F=To_float32();
         F-=I;
-        if (F>=0.5)
+        if (F>=0.5f)
             return (int8u)I+1;
     }
 
@@ -1931,7 +1931,7 @@ int16s Ztring::To_int16s (int8u Radix, ztring_t Options) const
     {
         float80 F=To_float80();
         F-=I;
-        if (F>=0.5)
+        if (F>=0.5f)
             return (int16s)I+1;
     }
 
@@ -1969,7 +1969,7 @@ int16u Ztring::To_int16u (int8u Radix, ztring_t Options) const
     {
         float32 F=To_float32();
         F-=I;
-        if (F>=0.5)
+        if (F>=0.5f)
             return (int16u)I+1;
     }
 
@@ -2007,7 +2007,7 @@ int32s Ztring::To_int32s (int8u Radix, ztring_t Options) const
     {
         float80 F=To_float80();
         F-=I;
-        if (F>=0.5)
+        if (F>=0.5f)
             return I+1;
     }
 
@@ -2045,7 +2045,7 @@ int32u Ztring::To_int32u (int8u Radix, ztring_t Options) const
     {
         float32 F=To_float32();
         F-=I;
-        if (F>=0.5)
+        if (F>=0.5f)
             return I+1;
     }
 
@@ -2083,7 +2083,7 @@ int64s Ztring::To_int64s (int8u Radix, ztring_t Options) const
     {
         float32 F=To_float32();
         F-=I;
-        if (F>0.5)
+        if (F>0.5f)
             return I+1;
     }
 
@@ -2121,7 +2121,7 @@ int64u Ztring::To_int64u (int8u Radix, ztring_t Options) const
     {
         float32 F=To_float32();
         F-=I;
-        if (F>=0.5)
+        if (F>=0.5f)
             return I+1;
     }
 


### PR DESCRIPTION
Follow up to https://github.com/MediaArea/ZenLib/pull/114#issuecomment-628702103

Part 1 of ?

My build script for this PR:
```sh
#!/usr/bin/env bash

set -euo pipefail
IFS=$'\n\t'

if [[ ! -d ZenLib ]]; then
  echo "Cloning ZenLib"
  git clone git@github.com:MediaArea/ZenLib.git
fi

cd ZenLib/Project/CMake

echo "Creating build dir"
rm -rf Build
mkdir Build && cd Build

export CXX=g++-mp-10 # MacPorts g++ variant
export CC=gcc-mp-10 # MacPorts gcc variant
# First enable all warnings and those that aren't enabled by -Wall and -Wextra
# then disable some so that we only get one error category.
# Disabled warnings are at the end.
export CXXFLAGS="-Wall -Wextra -Wunknown-pragmas -Wundef -Wdisabled-optimization -Wstrict-overflow=4 -Winit-self -Wpointer-arith -Wduplicated-cond -Wdouble-promotion -Wshadow -Wduplicated-branches -Wrestrict -Wnull-dereference -Wlogical-op -Wformat=2 -Wmissing-field-initializers -Wno-old-style-cast -Wno-unused-variable -Wno-deprecated-copy -Wno-implicit-fallthrough -Wno-useless-cast -Wunsafe-loop-optimizations -Wno-error=unsafe-loop-optimizations -Wno-undef -Wno-unused-parameter -Wno-strict-overflow -Wno-shadow"

cmake ..
make -j12
echo "Done"
```

Log:

<details>

```
Creating build dir
-- The C compiler identification is GNU 10.1.0
-- The CXX compiler identification is GNU 10.1.0
-- Checking whether C compiler has -isysroot
-- Checking whether C compiler has -isysroot - yes
-- Checking whether C compiler supports OSX deployment target flag
-- Checking whether C compiler supports OSX deployment target flag - yes
-- Check for working C compiler: /opt/local/bin/gcc-mp-10
-- Check for working C compiler: /opt/local/bin/gcc-mp-10 - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Checking whether CXX compiler has -isysroot
-- Checking whether CXX compiler has -isysroot - yes
-- Checking whether CXX compiler supports OSX deployment target flag
-- Checking whether CXX compiler supports OSX deployment target flag - yes
-- Check for working CXX compiler: /opt/local/bin/g++-mp-10
-- Check for working CXX compiler: /opt/local/bin/g++-mp-10 - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- 
-- 
-- Checking large files support...
-- 
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- 
-- Checking size of off_t without any definitions:
-- Check size of off_t
-- Check size of off_t - done
-- Checking of off_t without any definitions: 8
-- 
-- Result of checking large files support: supported


-- Check size of size_t
-- Check size of size_t - done
-- Check size of long
-- Check size of long - done
-- Found PkgConfig: /opt/local/bin/pkg-config (found version "0.29.2") 
-- Configuring done
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   zen

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
-- Build files have been written to: /Users/bugwelle/Projects/Private/ZenLib/Project/CMake/Build
Scanning dependencies of target zen
[  4%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/CriticalSection.cpp.o
[ 12%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Dir.cpp.o
[ 12%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Conf.cpp.o
[ 16%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/InfoMap.cpp.o
[ 20%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/File.cpp.o
[ 25%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/int128u.cpp.o
[ 29%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/OS_Utils.cpp.o
[ 41%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/MemoryDebug.cpp.o
[ 41%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/int128s.cpp.o
[ 41%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/FileName.cpp.o
[ 45%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Translation.cpp.o
[ 50%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Thread.cpp.o
[ 58%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp.o
[ 58%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Utils.cpp.o
[ 62%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/ZtringList.cpp.o
[ 66%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/ZtringListList.cpp.o
[ 70%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/ZtringListListF.cpp.o
[ 75%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Format/Html/Html_Handler.cpp.o
[ 79%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Format/Html/Html_Request.cpp.o
[ 83%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Format/Http/Http_Cookies.cpp.o
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Utils.cpp: In function 'ZenLib::int32s ZenLib::float32_int32s(ZenLib::float32, bool)':
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Utils.cpp:985:13: warning: implicit conversion from 'ZenLib::float32' {aka 'float'} to 'double' to match other operand of binary expression [-Wdouble-promotion]
  985 |     if (F-I1>=0.5)
      |         ~~~~^~~~~
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Utils.cpp: In function 'ZenLib::int64s ZenLib::float32_int64s(ZenLib::float32, bool)':
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Utils.cpp:1004:13: warning: implicit conversion from 'ZenLib::float32' {aka 'float'} to 'double' to match other operand of binary expression [-Wdouble-promotion]
 1004 |     if (F-I1>=0.5)
      |         ~~~~^~~~~
[ 87%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Format/Http/Http_Handler.cpp.o
[ 91%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Format/Http/Http_Request.cpp.o
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp: In member function 'ZenLib::int8u ZenLib::Ztring::To_int8u(ZenLib::int8u, ZenLib::ztring_t) const':
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp:1896:14: warning: implicit conversion from 'ZenLib::float32' {aka 'float'} to 'double' to match other operand of binary expression [-Wdouble-promotion]
 1896 |         if (F>=0.5)
      |             ~^~~~~
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp: In member function 'ZenLib::int16u ZenLib::Ztring::To_int16u(ZenLib::int8u, ZenLib::ztring_t) const':
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp:1972:14: warning: implicit conversion from 'ZenLib::float32' {aka 'float'} to 'double' to match other operand of binary expression [-Wdouble-promotion]
 1972 |         if (F>=0.5)
      |             ~^~~~~
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp: In member function 'ZenLib::int32u ZenLib::Ztring::To_int32u(ZenLib::int8u, ZenLib::ztring_t) const':
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp:2048:14: warning: implicit conversion from 'ZenLib::float32' {aka 'float'} to 'double' to match other operand of binary expression [-Wdouble-promotion]
 2048 |         if (F>=0.5)
      |             ~^~~~~
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp: In member function 'ZenLib::int64s ZenLib::Ztring::To_int64s(ZenLib::int8u, ZenLib::ztring_t) const':
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp:2086:14: warning: implicit conversion from 'ZenLib::float32' {aka 'float'} to 'double' to match other operand of binary expression [-Wdouble-promotion]
 2086 |         if (F>0.5)
      |             ~^~~~
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp: In member function 'ZenLib::int64u ZenLib::Ztring::To_int64u(ZenLib::int8u, ZenLib::ztring_t) const':
/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Ztring.cpp:2124:14: warning: implicit conversion from 'ZenLib::float32' {aka 'float'} to 'double' to match other operand of binary expression [-Wdouble-promotion]
 2124 |         if (F>=0.5)
      |             ~^~~~~
[ 95%] Building CXX object CMakeFiles/zen.dir/Users/bugwelle/Projects/Private/ZenLib/Source/ZenLib/Format/Http/Http_Utils.cpp.o
[100%] Linking CXX shared library libzen.dylib
[100%] Built target zen
Done
```

</details>