### PR TITLE
Ztring.cpp: Explicitly state that fallthrough is wanted; remove unused variable

### DIFF
--- a/Source/ZenLib/Ztring.cpp
+++ b/Source/ZenLib/Ztring.cpp
@@ -1643,18 +1643,23 @@ std::string Ztring::To_UTF8 () const
             case 6:
                 utf8chars[5] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x4000000;
+                /* fallthrough */
             case 5:
                 utf8chars[4] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x200000;
+                /* fallthrough */
             case 4:
                 utf8chars[3] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x10000;
+                /* fallthrough */
             case 3:
                 utf8chars[2] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x800;
+                /* fallthrough */
             case 2:
                 utf8chars[1] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0xc0;
+                /* fallthrough */
             case 1:
                 utf8chars[0] = (char) wc;
             }

--- a/Source/ZenLib/ZtringListList.cpp
+++ b/Source/ZenLib/ZtringListList.cpp
@@ -406,7 +406,6 @@ void ZtringListList::Write(const Ztring &ToWrite)
 
         if (y>=size())
         {
-            size_t PreviousSize=size();
             resize(y+1);
             for (size_t j=0; j<=y; j++)
             {


### PR DESCRIPTION
Follow up to #115
Same setup as #115. But enabled a few more warnings.

@JeromeMartinez `PreviousSize` is unused. I can't see any use for it or where it could have been used before. 

*Regarding "fallthrough" (commit message):*  
GCC10 warns about this switch case because cases "fall through" the
bottom. Adding a simple comment fixes the warning.
Note: C++17 has `[[fallthrough]]` but ZenLib supports older C++ versions
as well.