### PR TITLE
ZenLib: Fix "-pedantic" GCC warning and remove unnecessary semicolons

### DIFF
--- a/Source/ZenLib/int128s.cpp
+++ b/Source/ZenLib/int128s.cpp
@@ -75,7 +75,7 @@ const char * int128::toString (unsigned int radix) const throw () {
         sz [--i] = '-';
 
     return &sz [i];
-};
+}
 
 int128::int128 (const char * sz) throw ()
     : lo (0u), hi (0) {
@@ -120,7 +120,7 @@ int128::int128 (const char * sz) throw ()
         *this = 0 - *this;
 
     return;
-};
+}
 
 int128::int128 (const float a) throw ()
     #if defined (__mips__)       || defined (__mipsel__)
@@ -128,11 +128,11 @@ int128::int128 (const float a) throw ()
     #else
     : lo ((int64u) fmodf (a, 18446744073709551616.0f)),
     #endif
-      hi ((int64s) (a / 18446744073709551616.0f)) {};
+      hi ((int64s) (a / 18446744073709551616.0f)) {}
 
 int128::int128 (const double & a) throw ()
     : lo ((int64u) fmod (a, 18446744073709551616.0)),
-      hi ((int64s) (a / 18446744073709551616.0)) {};
+      hi ((int64s) (a / 18446744073709551616.0)) {}
 
 int128::int128 (const long double & a) throw ()
     #if defined (__mips__)       || defined (__mipsel__)
@@ -140,22 +140,22 @@ int128::int128 (const long double & a) throw ()
     #else
     : lo ((int64u) fmodl (a, 18446744073709551616.0l)),
     #endif
-      hi ((int64s) (a / 18446744073709551616.0l)) {};
+      hi ((int64s) (a / 18446744073709551616.0l)) {}
 
 float int128::toFloat () const throw () {
     return (float) this->hi * 18446744073709551616.0f
          + (float) this->lo;
-};
+}
 
 double int128::toDouble () const throw () {
     return (double) this->hi * 18446744073709551616.0
          + (double) this->lo;
-};
+}
 
 long double int128::toLongDouble () const throw () {
     return (long double) this->hi * 18446744073709551616.0l
          + (long double) this->lo;
-};
+}
 
 int128 int128::operator - () const throw () {
     if (!this->hi && !this->lo)
@@ -164,11 +164,11 @@ int128 int128::operator - () const throw () {
     else
         // non 0 number
         return int128 (0-this->lo, ~this->hi);
-};
+}
 
 int128 int128::operator ~ () const throw () {
     return int128 (~this->lo, ~this->hi);
-};
+}
 
 int128 & int128::operator ++ () {
     ++this->lo;
@@ -176,7 +176,7 @@ int128 & int128::operator ++ () {
         ++this->hi;
 
     return *this;
-};
+}
 
 int128 & int128::operator -- () {
     if (!this->lo)
@@ -184,21 +184,21 @@ int128 & int128::operator -- () {
     --this->lo;
 
     return *this;
-};
+}
 
 int128 int128::operator ++ (int) {
     int128 b = *this;
     ++ *this;
 
     return b;
-};
+}
 
 int128 int128::operator -- (int) {
     int128 b = *this;
     -- *this;
 
     return b;
-};
+}
 
 int128 & int128::operator += (const int128 & b) throw () {
     int64u old_lo = this->lo;
@@ -207,7 +207,7 @@ int128 & int128::operator += (const int128 & b) throw () {
     this->hi += b.hi + (this->lo < old_lo);
 
     return *this;
-};
+}
 
 int128 & int128::operator *= (const int128 & b) throw () {
     if (!b)
@@ -229,7 +229,7 @@ int128 & int128::operator *= (const int128 & b) throw () {
     };
 
     return *this;
-};
+}
 
 
 int128 int128::div (const int128 & divisor, int128 & remainder) const throw () {
@@ -278,7 +278,7 @@ int128 int128::div (const int128 & divisor, int128 & remainder) const throw () {
 
     remainder = r;
     return q;
-};
+}
 
 bool int128::bit (unsigned int n) const throw () {
     n &= 0x7F;
@@ -287,7 +287,7 @@ bool int128::bit (unsigned int n) const throw () {
         return (this->lo & (1ull << n))?true:false;
     else
         return (this->hi & (1ull << (n - 64)))?true:false;
-};
+}
 
 void int128::bit (unsigned int n, bool val) throw () {
     n &= 0x7F;
@@ -299,7 +299,7 @@ void int128::bit (unsigned int n, bool val) throw () {
         if (n < 64) this->lo &= ~(1ull << n);
                else this->hi &= ~(1ull << (n - 64));
     };
-};
+}
 
 
 int128 & int128::operator >>= (unsigned int n) throw () {
@@ -329,7 +329,7 @@ int128 & int128::operator >>= (unsigned int n) throw () {
     };
 
     return *this;
-};
+}
 
 int128 & int128::operator <<= (unsigned int n) throw () {
     n &= 0x7F;
@@ -356,32 +356,32 @@ int128 & int128::operator <<= (unsigned int n) throw () {
     };
 
     return *this;
-};
+}
 
 bool int128::operator ! () const throw () {
     return !(this->hi || this->lo);
-};
+}
 
 int128 & int128::operator |= (const int128 & b) throw () {
     this->hi |= b.hi;
     this->lo |= b.lo;
 
     return *this;
-};
+}
 
 int128 & int128::operator &= (const int128 & b) throw () {
     this->hi &= b.hi;
     this->lo &= b.lo;
 
     return *this;
-};
+}
 
 int128 & int128::operator ^= (const int128 & b) throw () {
     this->hi ^= b.hi;
     this->lo ^= b.lo;
 
     return *this;
-};
+}
 
 bool operator <  (const int128 & a, const int128 & b) throw () {
     if (a.hi == b.hi) {
@@ -391,16 +391,16 @@ bool operator <  (const int128 & a, const int128 & b) throw () {
             return a.lo < b.lo;
     } else
         return a.hi < b.hi;
-};
+}
 
 bool operator == (const int128 & a, const int128 & b) throw () {
     return a.hi == b.hi && a.lo == b.lo;
-};
+}
 bool operator && (const int128 & a, const int128 & b) throw () {
     return (a.hi || a.lo) && (b.hi || b.lo);
-};
+}
 bool operator || (const int128 & a, const int128 & b) throw () {
     return (a.hi || a.lo) || (b.hi || b.lo);
-};
+}
 
 } //NameSpace

--- a/Source/ZenLib/int128s.h
+++ b/Source/ZenLib/int128s.h
@@ -153,36 +153,36 @@ bool operator && (const int128 & a, const int128 & b) throw ();
 // GLOBAL OPERATOR INLINES
 
 inline int128 operator + (const int128 & a, const int128 & b) throw () {
-    return int128 (a) += b; };
+    return int128 (a) += b; }
 inline int128 operator - (const int128 & a, const int128 & b) throw () {
-    return int128 (a) -= b; };
+    return int128 (a) -= b; }
 inline int128 operator * (const int128 & a, const int128 & b) throw () {
-    return int128 (a) *= b; };
+    return int128 (a) *= b; }
 inline int128 operator / (const int128 & a, const int128 & b) throw () {
-    return int128 (a) /= b; };
+    return int128 (a) /= b; }
 inline int128 operator % (const int128 & a, const int128 & b) throw () {
-    return int128 (a) %= b; };
+    return int128 (a) %= b; }
 
 inline int128 operator >> (const int128 & a, unsigned int n) throw () {
-    return int128 (a) >>= n; };
+    return int128 (a) >>= n; }
 inline int128 operator << (const int128 & a, unsigned int n) throw () {
-    return int128 (a) <<= n; };
+    return int128 (a) <<= n; }
 
 inline int128 operator & (const int128 & a, const int128 & b) throw () {
-    return int128 (a) &= b; };
+    return int128 (a) &= b; }
 inline int128 operator | (const int128 & a, const int128 & b) throw () {
-    return int128 (a) |= b; };
+    return int128 (a) |= b; }
 inline int128 operator ^ (const int128 & a, const int128 & b) throw () {
-    return int128 (a) ^= b; };
+    return int128 (a) ^= b; }
 
 inline bool operator >  (const int128 & a, const int128 & b) throw () {
-    return   b < a; };
+    return   b < a; }
 inline bool operator <= (const int128 & a, const int128 & b) throw () {
-    return !(b < a); };
+    return !(b < a); }
 inline bool operator >= (const int128 & a, const int128 & b) throw () {
-    return !(a < b); };
+    return !(a < b); }
 inline bool operator != (const int128 & a, const int128 & b) throw () {
-    return !(a == b); };
+    return !(a == b); }
 
 
 // MISC

--- a/Source/ZenLib/int128u.cpp
+++ b/Source/ZenLib/int128u.cpp
@@ -72,7 +72,7 @@ const char * uint128::toString (unsigned int radix) const throw () {
     };
 
     return &sz [i];
-};
+}
 
 uint128::uint128 (const char * sz) throw ()
     : lo (0u), hi (0u) {
@@ -117,7 +117,7 @@ uint128::uint128 (const char * sz) throw ()
         *this = 0u - *this;
 
     return;
-};
+}
 
 uint128::uint128 (const float a) throw ()
     #if defined (__mips__)       || defined (__mipsel__)
@@ -125,11 +125,11 @@ uint128::uint128 (const float a) throw ()
     #else
     : lo ((int64u) fmodf (a, 18446744073709551616.0f)),
     #endif
-      hi ((int64u) (a / 18446744073709551616.0f)) {};
+      hi ((int64u) (a / 18446744073709551616.0f)) {}
 
 uint128::uint128 (const double & a) throw ()
     : lo ((int64u) fmod (a, 18446744073709551616.0)),
-      hi ((int64u) (a / 18446744073709551616.0)) {};
+      hi ((int64u) (a / 18446744073709551616.0)) {}
 
 uint128::uint128 (const long double & a) throw ()
     #if defined (__mips__)       || defined (__mipsel__)
@@ -137,22 +137,22 @@ uint128::uint128 (const long double & a) throw ()
     #else
     : lo ((int64u) fmodl (a, 18446744073709551616.0l)),
     #endif
-      hi ((int64u) (a / 18446744073709551616.0l)) {};
+      hi ((int64u) (a / 18446744073709551616.0l)) {}
 
 float uint128::toFloat () const throw () {
     return (float) this->hi * 18446744073709551616.0f
          + (float) this->lo;
-};
+}
 
 double uint128::toDouble () const throw () {
     return (double) this->hi * 18446744073709551616.0
          + (double) this->lo;
-};
+}
 
 long double uint128::toLongDouble () const throw () {
     return (long double) this->hi * 18446744073709551616.0l
          + (long double) this->lo;
-};
+}
 
 uint128 uint128::operator - () const throw () {
     if (!this->hi && !this->lo)
@@ -161,11 +161,11 @@ uint128 uint128::operator - () const throw () {
     else
         // non 0 number
         return uint128 (0-this->lo, ~this->hi);
-};
+}
 
 uint128 uint128::operator ~ () const throw () {
     return uint128 (~this->lo, ~this->hi);
-};
+}
 
 uint128 & uint128::operator ++ () {
     ++this->lo;
@@ -173,7 +173,7 @@ uint128 & uint128::operator ++ () {
         ++this->hi;
 
     return *this;
-};
+}
 
 uint128 & uint128::operator -- () {
     if (!this->lo)
@@ -181,21 +181,21 @@ uint128 & uint128::operator -- () {
     --this->lo;
 
     return *this;
-};
+}
 
 uint128 uint128::operator ++ (int) {
     uint128 b = *this;
     ++ *this;
 
     return b;
-};
+}
 
 uint128 uint128::operator -- (int) {
     uint128 b = *this;
     -- *this;
 
     return b;
-};
+}
 
 uint128 & uint128::operator += (const uint128 & b) throw () {
     int64u old_lo = this->lo;
@@ -204,7 +204,7 @@ uint128 & uint128::operator += (const uint128 & b) throw () {
     this->hi += b.hi + (this->lo < old_lo);
 
     return *this;
-};
+}
 
 uint128 & uint128::operator *= (const uint128 & b) throw () {
     if (!b)
@@ -226,7 +226,7 @@ uint128 & uint128::operator *= (const uint128 & b) throw () {
     };
 
     return *this;
-};
+}
 
 
 uint128 uint128::div (const uint128 & ds, uint128 & remainder) const throw () {
@@ -268,7 +268,7 @@ uint128 uint128::div (const uint128 & ds, uint128 & remainder) const throw () {
 
     remainder = r;
     return q;
-};
+}
 
 bool uint128::bit (unsigned int n) const throw () {
     n &= 0x7F;
@@ -277,7 +277,7 @@ bool uint128::bit (unsigned int n) const throw () {
         return (this->lo & (1ull << n))?true:false;
     else
         return (this->hi & (1ull << (n - 64)))?true:false;
-};
+}
 
 void uint128::bit (unsigned int n, bool val) throw () {
     n &= 0x7F;
@@ -289,7 +289,7 @@ void uint128::bit (unsigned int n, bool val) throw () {
         if (n < 64) this->lo &= ~(1ull << n);
                else this->hi &= ~(1ull << (n - 64));
     };
-};
+}
 
 
 uint128 & uint128::operator >>= (unsigned int n) throw () {
@@ -317,7 +317,7 @@ uint128 & uint128::operator >>= (unsigned int n) throw () {
     };
 
     return *this;
-};
+}
 
 uint128 & uint128::operator <<= (unsigned int n) throw () {
     n &= 0x7F;
@@ -344,45 +344,45 @@ uint128 & uint128::operator <<= (unsigned int n) throw () {
     };
 
     return *this;
-};
+}
 
 bool uint128::operator ! () const throw () {
     return !(this->hi || this->lo);
-};
+}
 
 uint128 & uint128::operator |= (const uint128 & b) throw () {
     this->hi |= b.hi;
     this->lo |= b.lo;
 
     return *this;
-};
+}
 
 uint128 & uint128::operator &= (const uint128 & b) throw () {
     this->hi &= b.hi;
     this->lo &= b.lo;
 
     return *this;
-};
+}
 
 uint128 & uint128::operator ^= (const uint128 & b) throw () {
     this->hi ^= b.hi;
     this->lo ^= b.lo;
 
     return *this;
-};
+}
 
 bool operator <  (const uint128 & a, const uint128 & b) throw () {
     return (a.hi == b.hi) ? (a.lo < b.lo) : (a.hi < b.hi);
-};
+}
 
 bool operator == (const uint128 & a, const uint128 & b) throw () {
     return a.hi == b.hi && a.lo == b.lo;
-};
+}
 bool operator && (const uint128 & a, const uint128 & b) throw () {
     return (a.hi || a.lo) && (b.hi || b.lo);
-};
+}
 bool operator || (const uint128 & a, const uint128 & b) throw () {
     return (a.hi || a.lo) || (b.hi || b.lo);
-};
+}
 
 } //NameSpace

--- a/Source/ZenLib/int128u.h
+++ b/Source/ZenLib/int128u.h
@@ -95,7 +95,7 @@ class uint128 {
         uint128 & operator ^= (const uint128 & b) throw ();
 
         // Inline simple operators
-        inline const uint128 & operator + () const throw () { return *this; };
+        inline const uint128 & operator + () const throw () { return *this; }
 
         // Rest of inline operators
         inline uint128 & operator -= (const uint128 & b) throw () {
@@ -113,9 +113,9 @@ class uint128 {
 
         // Common methods
         unsigned int toUint () const throw () {
-            return (unsigned int) this->lo; };
+            return (unsigned int) this->lo; }
         int64u toUint64 () const throw () {
-            return (int64u) this->lo; };
+            return (int64u) this->lo; }
         const char * toString (unsigned int radix = 10) const throw ();
         float toFloat () const throw ();
         double toDouble () const throw ();
@@ -144,36 +144,36 @@ bool operator && (const uint128 & a, const uint128 & b) throw ();
 // GLOBAL OPERATOR INLINES
 
 inline uint128 operator + (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) += b; };
+    return uint128 (a) += b; }
 inline uint128 operator - (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) -= b; };
+    return uint128 (a) -= b; }
 inline uint128 operator * (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) *= b; };
+    return uint128 (a) *= b; }
 inline uint128 operator / (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) /= b; };
+    return uint128 (a) /= b; }
 inline uint128 operator % (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) %= b; };
+    return uint128 (a) %= b; }
 
 inline uint128 operator >> (const uint128 & a, unsigned int n) throw () {
-    return uint128 (a) >>= n; };
+    return uint128 (a) >>= n; }
 inline uint128 operator << (const uint128 & a, unsigned int n) throw () {
-    return uint128 (a) <<= n; };
+    return uint128 (a) <<= n; }
 
 inline uint128 operator & (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) &= b; };
+    return uint128 (a) &= b; }
 inline uint128 operator | (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) |= b; };
+    return uint128 (a) |= b; }
 inline uint128 operator ^ (const uint128 & a, const uint128 & b) throw () {
-    return uint128 (a) ^= b; };
+    return uint128 (a) ^= b; }
 
 inline bool operator >  (const uint128 & a, const uint128 & b) throw () {
-    return   b < a; };
+    return   b < a; }
 inline bool operator <= (const uint128 & a, const uint128 & b) throw () {
-    return !(b < a); };
+    return !(b < a); }
 inline bool operator >= (const uint128 & a, const uint128 & b) throw () {
-    return !(a < b); };
+    return !(a < b); }
 inline bool operator != (const uint128 & a, const uint128 & b) throw () {
-    return !(a == b); };
+    return !(a == b); }
 
 
 // MISC


### PR DESCRIPTION
Follow up to #116

Likely the last change regarding warning-fixes. :-)