### PR TITLE
Fix checks for gmtime_r availability.

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -133,6 +133,16 @@ if((LONG_SIZE GREATER 4) AND (SIZE_T_SIZE EQUAL LONG_SIZE))
   target_compile_definitions(zen PUBLIC SIZE_T_IS_LONG)
 endif()
 
+include(CheckSymbolExists)
+check_symbol_exists(gmtime_r time.h HAVE_GMTIME_R)
+if(HAVE_GMTIME_R)
+  target_compile_definitions(zen PUBLIC HAVE_GMTIME_R)
+endif()
+check_symbol_exists(localtime_r time.h HAVE_LOCALTIME_R)
+if(HAVE_LOCALTIME_R)
+  target_compile_definitions(zen PUBLIC HAVE_LOCALTIME_R)
+endif()
+
 target_include_directories(zen PUBLIC
   $<BUILD_INTERFACE:${ZenLib_SOURCES_PATH}>
   $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>)

--- a/Project/GNU/Library/configure.ac
+++ b/Project/GNU/Library/configure.ac
@@ -254,6 +254,11 @@ dnl External libs
 dnl
 LDFLAGS="$LDFLAGS -lpthread"
 
+dnl -------------------------------------------------------------------------
+dnl Check if thread safe variants of time functions are available
+dnl
+AC_CHECK_FUNCS(gmtime_r localtime_r)
+
 dnl #########################################################################
 dnl ### Output
 dnl #########################################################################

--- a/Source/ZenLib/Ztring.cpp
+++ b/Source/ZenLib/Ztring.cpp
@@ -1312,7 +1312,7 @@ Ztring& Ztring::Date_From_Seconds_1970 (const int32s Value)
 Ztring& Ztring::Date_From_Seconds_1970 (const int64s Value)
 {
     time_t Time=(time_t)Value;
-    #if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _BSD_SOURCE || _SVID_SOURCE || _POSIX_SOURCE
+    #if defined(HAVE_GMTIME_R)
     struct tm Gmt_Temp;
     struct tm *Gmt=gmtime_r(&Time, &Gmt_Temp);
     #elif defined(_MSC_VER)
@@ -1320,6 +1320,9 @@ Ztring& Ztring::Date_From_Seconds_1970 (const int64s Value)
     errno_t gmtime_s_Result=gmtime_s(&Gmt_Temp , &Time);
     struct tm* Gmt=gmtime_s_Result?NULL:&Gmt_Temp;
     #else
+    #ifdef __GNUC__
+    #warning "This version of ZenLib is not thread safe"
+    #endif
     struct tm *Gmt=gmtime(&Time);
     #endif
     if (!Gmt)
@@ -1352,7 +1355,7 @@ Ztring& Ztring::Date_From_Seconds_1970 (const int64s Value)
 Ztring& Ztring::Date_From_Seconds_1970_Local (const int32u Value)
 {
     time_t Time=(time_t)Value;
-    #if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _BSD_SOURCE || _SVID_SOURCE || _POSIX_SOURCE
+    #if defined(HAVE_LOCALTIME_R)
     struct tm Gmt_Temp;
     struct tm *Gmt=localtime_r(&Time, &Gmt_Temp);
     #elif defined(_MSC_VER)
@@ -1360,6 +1363,9 @@ Ztring& Ztring::Date_From_Seconds_1970_Local (const int32u Value)
     errno_t localtime_s_Result=localtime_s(&Gmt_Temp , &Time);
     struct tm* Gmt=localtime_s_Result?NULL:&Gmt_Temp;
     #else
+    #ifdef __GNUC__
+    #warning "This version of ZenLib is not thread safe"
+    #endif
     struct tm *Gmt=localtime(&Time);
     #endif
     Ztring DateT;


### PR DESCRIPTION
Actually check for the function in configure.ac, which is the only way
of definitively testing for it. This does not add such detection to any
other builds, such as the CMake one.

Add a warning for cases where gmtime() is used.

Also fix Http_Cookies where gmtime() was still being used.