### PR TITLE
bool functions returning Error instead of false

### DIFF
--- a/Source/ZenLib/ZtringListListF.cpp
+++ b/Source/ZenLib/ZtringListListF.cpp
@@ -264,7 +264,7 @@ bool ZtringListListF::CSV_Sauvegarder ()
     //Sauvegarde
     File F;
     if (!F.Create(Name, true))
-        return Error;
+        return false;
 
     if (Separator[0]==__T("(Default)"))
         Separator[0]=EOL;
@@ -280,7 +280,7 @@ bool ZtringListListF::CFG_Sauvegarder ()
 {
     File F;
     if (!F.Create(Name, true))
-        return Error;
+        return false;
 
     Ztring ToWrite;
     Ztring Propriete, Valeur, Commentaire;


### PR DESCRIPTION
ZtringListListF::CSV_Sauvegarder and ZtringListListF::CFG_Sauvegarder both have bool return type, but would return Error if they failed to create a file.

Error is (size_t)-1 which, at least on my setup, results in a compilation warning/error when assigned to a bool. Error would also turn into "true" rather than "false", so I think this must have been a copy and paste bug.