### PR TITLE
Use llvm bcc32c compiler for borland project

### DIFF
--- a/Project/BCB/Library/ZenLib.cbproj
+++ b/Project/BCB/Library/ZenLib.cbproj
@@ -44,6 +44,7 @@
 			<BCC_wpar>false</BCC_wpar>
 			<BCC_OptimizeForSpeed>true</BCC_OptimizeForSpeed>
 			<BCC_ExtendedErrorInfo>true</BCC_ExtendedErrorInfo>
+			<BCC_UseClassicCompiler>false</BCC_UseClassicCompiler>
 			<ILINK_TranslatedLibraryPath>$(BDSLIB)\$(PLATFORM)\release\$(LANGDIR);$(ILINK_TranslatedLibraryPath)</ILINK_TranslatedLibraryPath>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Base_Win32)'!=''">

--- a/Source/ZenLib/HTTP_Client/HTTPClient.c
+++ b/Source/ZenLib/HTTP_Client/HTTPClient.c
@@ -309,6 +309,7 @@ UINT32  HTTPClientSetAuth (HTTP_SESSION_HANDLE pSession,
     case(AuthSchemaKerberos):
         strcpy(pHTTPSession->HttpCredentials.AuthSchemaName,"negotiate");
         break;
+    default: break;
     };
 
     if(AuthSchema >= AuthNotSupported)
@@ -1182,7 +1183,7 @@ UINT32 HTTPClientGetNextHeader (HTTP_SESSION_HANDLE pSession, CHAR *pHeaderBuffe
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnSetURL (P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnSetURL (P_HTTP_SESSION pHTTPSession,
                         CHAR *pUrl,         // [IN] a null terminated string containing the Url we should retrieve
                         UINT32 nUrlLength)  // [IN] The length the Url string
 {
@@ -1334,7 +1335,7 @@ static UINT32 HTTPIntrnSetURL (P_HTTP_SESSION pHTTPSession,
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnResizeBuffer (P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnResizeBuffer (P_HTTP_SESSION pHTTPSession,
                               UINT32 nNewBufferSize)    // [IN] The new (and larger) buffer size
 {
 
@@ -1404,7 +1405,7 @@ static UINT32 HTTPIntrnResizeBuffer (P_HTTP_SESSION pHTTPSession,
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnHeadersRemove (P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnHeadersRemove (P_HTTP_SESSION pHTTPSession,
                                CHAR *pHeaderName)   // [IN] The header's name
 
 {
@@ -1464,7 +1465,7 @@ static UINT32 HTTPIntrnHeadersRemove (P_HTTP_SESSION pHTTPSession,
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnHeadersAdd (P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnHeadersAdd (P_HTTP_SESSION pHTTPSession,
                             CHAR *pHeaderName,   // [IN] The header's name
                             UINT32 nNameLength,  // [IN] Name length
                             CHAR *pHeaderData,   // [IN] The Header's data
@@ -1615,14 +1616,14 @@ UINT32 HTTPIntrnConnectionClose (P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnConnectionOpen (P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnConnectionOpen (P_HTTP_SESSION pHTTPSession)
 {
     INT32            nRetCode = HTTP_CLIENT_SUCCESS;     // a function return code value
     UINT32           nNullOffset;                        // a helper value to null terminate a given string
-    int              nNonBlocking    = 1;                // non blocking mode parameter
+    ULONG            nNonBlocking    = 1;                // non blocking mode parameter
     CHAR             Backup;                             // a container for a char value (helps in temporary null termination)
     // HTTP_HOSTNET     *HostEntry;                          // Socket host entry pointer
-    UINT32           Address = 0;
+    ULONG            Address = 0;
     HTTP_SOCKADDR_IN ServerAddress;                      // Socket address structure
     HTTP_SOCKADDR_IN LoaclAddress;                       // Socket address structure (for client binding)
     do
@@ -1802,7 +1803,7 @@ static UINT32 HTTPIntrnConnectionOpen (P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnSend (P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnSend (P_HTTP_SESSION pHTTPSession,
                       CHAR *pData,            // [IN] a pointer to the data to be sent
                       UINT32 *nLength)        // [IN OUT] Length of data to send and the transmitted bytes count
 {
@@ -1927,7 +1928,7 @@ static UINT32 HTTPIntrnSend (P_HTTP_SESSION pHTTPSession,
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnRecv (P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnRecv (P_HTTP_SESSION pHTTPSession,
                       CHAR *pData,        // [IN] a pointer for a buffer that receives the data
                       UINT32 *nLength,    // [IN OUT] Length of the buffer and the count of the received bytes
                       BOOL PeekOnly)      // [IN] State if we should only peek the socket (default is no)
@@ -2092,7 +2093,7 @@ static UINT32 HTTPIntrnRecv (P_HTTP_SESSION pHTTPSession,
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnGetRemoteChunkLength (P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnGetRemoteChunkLength (P_HTTP_SESSION pHTTPSession)
 {
 
     UINT32          nBytesRead = 1;
@@ -2172,7 +2173,7 @@ static UINT32 HTTPIntrnGetRemoteChunkLength (P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnGetRemoteHeaders (P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnGetRemoteHeaders (P_HTTP_SESSION pHTTPSession)
 {
 
     UINT32          nBytesRead = 1;
@@ -2288,7 +2289,7 @@ static UINT32 HTTPIntrnGetRemoteHeaders (P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnHeadersFind (P_HTTP_SESSION pHTTPSession,CHAR *pHeaderName,
+UINT32 HTTPIntrnHeadersFind (P_HTTP_SESSION pHTTPSession,CHAR *pHeaderName,
                              HTTP_PARAM *pParam,     //  [OUT] HTTP parameter structure that holds the search results
                              BOOL IncommingHeaders,  //  [IN]  Indicate if we are to search in the incoming or outgoing headers
                              UINT32 nOffset)         //  [IN]  Optionaly privide an offset to start looking from
@@ -2365,7 +2366,7 @@ static UINT32 HTTPIntrnHeadersFind (P_HTTP_SESSION pHTTPSession,CHAR *pHeaderNam
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnAuthenticate(P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnAuthenticate(P_HTTP_SESSION pHTTPSession)
 {
     UINT32      nRetCode = HTTP_CLIENT_SUCCESS;   // Function call return code
     UINT32      nBytes = 32;
@@ -2451,7 +2452,7 @@ static UINT32 HTTPIntrnAuthenticate(P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnHeadersParse (P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnHeadersParse (P_HTTP_SESSION pHTTPSession)
 {
 
     CHAR            *pPtr;                                      // a pointer that points on the incoming headers
@@ -2650,7 +2651,7 @@ static UINT32 HTTPIntrnHeadersParse (P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnParseAuthHeader(P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnParseAuthHeader(P_HTTP_SESSION pHTTPSession)
 {
 
     CHAR            *pPtrStart, *pPtrEnd;
@@ -2730,7 +2731,7 @@ static UINT32 HTTPIntrnParseAuthHeader(P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnHeadersSend(P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnHeadersSend(P_HTTP_SESSION pHTTPSession,
                             HTTP_VERB HttpVerb)  // [IN] Argument that can bypass the requested verb
                             // Can be used for evaluating a HEAD request
 {
@@ -2922,7 +2923,7 @@ static UINT32 HTTPIntrnHeadersSend(P_HTTP_SESSION pHTTPSession,
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnAuthHandler (P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnAuthHandler (P_HTTP_SESSION pHTTPSession)
 {
 
     UINT32 nRetCode = HTTP_CLIENT_SUCCESS;
@@ -2999,7 +3000,7 @@ static UINT32 HTTPIntrnAuthHandler (P_HTTP_SESSION pHTTPSession)
 ///////////////////////////////////////////////////////////////////////////////
 
 
-static UINT32 HTTPIntrnAuthSendBasic (P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnAuthSendBasic (P_HTTP_SESSION pHTTPSession)
 {
 
     UINT32      nSegmentLength;
@@ -3122,7 +3123,7 @@ static UINT32 HTTPIntrnAuthSendBasic (P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnAuthSendDigest (P_HTTP_SESSION pHTTPSession)
+UINT32 HTTPIntrnAuthSendDigest (P_HTTP_SESSION pHTTPSession)
 {
     CHAR        Cnonce[33];
     UINT32      nSegmentLength;
@@ -3442,7 +3443,7 @@ static UINT32 HTTPIntrnAuthSendDigest (P_HTTP_SESSION pHTTPSession)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnSessionReset (P_HTTP_SESSION pHTTPSession, BOOL EntireSession)
+UINT32 HTTPIntrnSessionReset (P_HTTP_SESSION pHTTPSession, BOOL EntireSession)
 {
     UINT32 nActionTimeout; // For restoring a parameter after this reset
     UINT32 nAllocationSize;
@@ -3519,7 +3520,7 @@ static UINT32 HTTPIntrnSessionReset (P_HTTP_SESSION pHTTPSession, BOOL EntireSes
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnHeadersReceive (P_HTTP_SESSION pHTTPSession,
+UINT32 HTTPIntrnHeadersReceive (P_HTTP_SESSION pHTTPSession,
                                 UINT32 nTimeout)        // [IN] Timeout for the operation
 
 {
@@ -3606,7 +3607,7 @@ static UINT32 HTTPIntrnHeadersReceive (P_HTTP_SESSION pHTTPSession,
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static UINT32 HTTPIntrnSessionGetUpTime(VOID)
+UINT32 HTTPIntrnSessionGetUpTime(VOID)
 {
 
     return GetUpTime();
@@ -3623,7 +3624,7 @@ static UINT32 HTTPIntrnSessionGetUpTime(VOID)
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-static BOOL HTTPIntrnSessionEvalTimeout(P_HTTP_SESSION pHTTPSession)
+BOOL HTTPIntrnSessionEvalTimeout(P_HTTP_SESSION pHTTPSession)
 {
 
     UINT32 nElapsedTime;    // Integer for calculating the elapsed time

--- a/Source/ZenLib/Utils.h
+++ b/Source/ZenLib/Utils.h
@@ -76,7 +76,6 @@ void   float322LittleEndian   (char* List, float32 Value);
 void   float642LittleEndian   (char* List, float64 Value);
 void   float802LittleEndian   (char* List, float80 Value);
 
-#ifndef __BORLANDC__
 inline int8s  LittleEndian2int8s  (const int8u* List) {return LittleEndian2int8s  ((const char*)List);}
 inline int8u  LittleEndian2int8u  (const int8u* List) {return LittleEndian2int8u  ((const char*)List);}
 inline int16s LittleEndian2int16s (const int8u* List) {return LittleEndian2int16s ((const char*)List);}
@@ -124,7 +123,6 @@ inline void   float162LittleEndian   (int8u* List, float32 Value) {return float1
 inline void   float322LittleEndian   (int8u* List, float32 Value) {return float322LittleEndian ((char*)List, Value);}
 inline void   float642LittleEndian   (int8u* List, float64 Value) {return float642LittleEndian ((char*)List, Value);}
 inline void   float802LittleEndian   (int8u* List, float80 Value) {return float802LittleEndian ((char*)List, Value);}
-#endif //__BORLANDC__
 
 //---------------------------------------------------------------------------
 //Big Endians
@@ -176,7 +174,6 @@ void   float322BigEndian   (char* List, float32 Value);
 void   float642BigEndian   (char* List, float64 Value);
 void   float802BigEndian   (char* List, float80 Value);
 
-#ifndef __BORLANDC__
 inline int8s  BigEndian2int8s     (const int8u* List) {return BigEndian2int8s     ((const char*)List);}
 inline int8u  BigEndian2int8u     (const int8u* List) {return BigEndian2int8u     ((const char*)List);}
 inline int16s BigEndian2int16s    (const int8u* List) {return BigEndian2int16s    ((const char*)List);}
@@ -224,7 +221,6 @@ inline void   float162BigEndian   (int8u* List, float32 Value) {return float162B
 inline void   float322BigEndian   (int8u* List, float32 Value) {return float322BigEndian ((char*)List, Value);}
 inline void   float642BigEndian   (int8u* List, float64 Value) {return float642BigEndian ((char*)List, Value);}
 inline void   float802BigEndian   (int8u* List, float80 Value) {return float802BigEndian ((char*)List, Value);}
-#endif //__BORLANDC__
 
 //---------------------------------------------------------------------------
 // int32 - int64
@@ -261,7 +257,6 @@ inline int32u CC4(const char*  C) {return BigEndian2int32u(C);}
 inline int32u CC3(const char*  C) {return BigEndian2int24u(C);}
 inline int16u CC2(const char*  C) {return BigEndian2int16u(C);}
 inline int8u  CC1(const char*  C) {return BigEndian2int8u (C);}
-#ifndef __BORLANDC__
 inline int64u CC8(const int8u* C) {return BigEndian2int64u(C);}
 inline int64u CC7(const int8u* C) {return BigEndian2int56u(C);}
 inline int64u CC6(const int8u* C) {return BigEndian2int48u(C);}
@@ -270,7 +265,6 @@ inline int32u CC4(const int8u* C) {return BigEndian2int32u(C);}
 inline int32u CC3(const int8u* C) {return BigEndian2int24u(C);}
 inline int16u CC2(const int8u* C) {return BigEndian2int16u(C);}
 inline int8u  CC1(const int8u* C) {return BigEndian2int8u (C);}
-#endif // __BORLANDC__
 
 //---------------------------------------------------------------------------
 // turn a numeric literal into a hex constant


### PR DESCRIPTION
Drop support of classic bcc32 compiler dues to missing c++11 features