### PR TITLE
add missing shellapi include

### DIFF
--- a/Source/ZenLib/OS_Utils.cpp
+++ b/Source/ZenLib/OS_Utils.cpp
@@ -40,6 +40,7 @@
             using namespace ABI::Windows::Security::Cryptography::Core;
         #else
             #include <shlobj.h>
+            #include <shellapi.h>
         #endif
     #endif
 #endif //ZENLIB_USEWX


### PR DESCRIPTION
ShellExecture requires this header. It's not defined when using WIN32_LEAN_AND_MEAN.