### PR TITLE
Resolve warnings from Visual Studio Code analysis + Set C++20 standard and Level 3 warnings for MSVC2022

### DIFF
--- a/Project/MSVC2022/Library/ZenLib.vcxproj
+++ b/Project/MSVC2022/Library/ZenLib.vcxproj
@@ -160,6 +160,8 @@
       <PrecompiledHeaderFile>ZenLib/PreComp.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -170,6 +172,8 @@
       <PrecompiledHeaderFile>ZenLib/PreComp.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -180,6 +184,8 @@
       <PrecompiledHeaderFile>ZenLib/PreComp.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64EC'">
@@ -190,6 +196,8 @@
       <PrecompiledHeaderFile>ZenLib/PreComp.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -200,7 +208,8 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>ZenLib/PreComp.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -213,6 +222,8 @@
       <DebugInformationFormat>None</DebugInformationFormat>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -224,6 +235,8 @@
       <PrecompiledHeaderFile>ZenLib/PreComp.h</PrecompiledHeaderFile>
       <DebugInformationFormat>None</DebugInformationFormat>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -237,6 +250,8 @@
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
       <GuardSignedReturns>true</GuardSignedReturns>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">
@@ -250,6 +265,8 @@
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
       <GuardSignedReturns>true</GuardSignedReturns>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -262,6 +279,8 @@
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <WarningLevel>Level3</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/ZenLib/BitStream.h
+++ b/Source/ZenLib/BitStream.h
@@ -30,16 +30,32 @@ namespace ZenLib
 class BitStream
 {
 public:
-    BitStream ()                                                                {Buffer=NULL;
-                                                                                 Buffer_Size=Buffer_Size_Init=Buffer_Size_BeforeLastCall=0;
-                                                                                 LastByte_Size=0;
-                                                                                 BufferUnderRun=true;
-                                                                                 BookMark=false;}
-    BitStream (const int8u* Buffer_, size_t Size_)                              {Buffer=Buffer_;
-                                                                                 Buffer_Size=Buffer_Size_Init=Buffer_Size_BeforeLastCall=Size_*8; //Size is in bits
-                                                                                 LastByte_Size=0;
-                                                                                 BufferUnderRun=Buffer_Size?false:true;
-                                                                                 BookMark=false;}
+    BitStream ()                                                                { Buffer = NULL;
+                                                                                  Buffer_Size = 0;
+                                                                                  Buffer_Size_Init = 0;
+                                                                                  Buffer_Size_BeforeLastCall = 0;
+                                                                                  LastByte = 0;
+                                                                                  LastByte_Size = 0;
+                                                                                  BufferUnderRun = true;
+                                                                                  BookMark = false;
+                                                                                  Buffer_BookMark = 0;
+                                                                                  Buffer_Size_BookMark = 0;
+                                                                                  LastByte_BookMark = 0;
+                                                                                  LastByte_Size_BookMark = 0;
+                                                                                  BufferUnderRun_BookMark = false; }
+    BitStream (const int8u* Buffer_, size_t Size_)                              { Buffer = Buffer_;
+                                                                                  Buffer_Size = Size_ * 8; //Size is in bits
+                                                                                  Buffer_Size_Init = Size_ * 8; //Size is in bits
+                                                                                  Buffer_Size_BeforeLastCall = Size_ * 8; //Size is in bits
+                                                                                  LastByte = 0;
+                                                                                  LastByte_Size = 0;
+                                                                                  BufferUnderRun = (Buffer_Size ? false : true);
+                                                                                  BookMark = false;
+                                                                                  Buffer_BookMark = 0;
+                                                                                  Buffer_Size_BookMark = 0;
+                                                                                  LastByte_BookMark = 0;
+                                                                                  LastByte_Size_BookMark = 0;
+                                                                                  BufferUnderRun_BookMark = false; }
     virtual ~BitStream ()                                                       {};
 
     virtual void Attach(const int8u* Buffer_, size_t Size_)

--- a/Source/ZenLib/BitStream.h
+++ b/Source/ZenLib/BitStream.h
@@ -98,14 +98,17 @@ public:
                             ToReturn |= ((size_t)*Buffer) << NewBits;
                             Buffer++;
                             Buffer_Size-=8;
+                            [[fallthrough]];
                 case 2 :    NewBits-=8;
                             ToReturn |= ((size_t)*Buffer) << NewBits;
                             Buffer++;
                             Buffer_Size-=8;
+                            [[fallthrough]];
                 case 1 :    NewBits-=8;
                             ToReturn |= ((size_t)*Buffer) << NewBits;
                             Buffer++;
                             Buffer_Size-=8;
+                            [[fallthrough]];
                 case 0 :
                             LastByte=*Buffer;
                             Buffer++;
@@ -191,12 +194,15 @@ public:
                 case 3 :    NewBits-=8;
                             Buffer++;
                             Buffer_Size-=8;
+                            [[fallthrough]];
                 case 2 :    NewBits-=8;
                             Buffer++;
                             Buffer_Size-=8;
+                            [[fallthrough]];
                 case 1 :    NewBits-=8;
                             Buffer++;
                             Buffer_Size-=8;
+                            [[fallthrough]];
                 case 0 :
                             LastByte=*Buffer;
                             Buffer++;

--- a/Source/ZenLib/BitStream_Fast.h
+++ b/Source/ZenLib/BitStream_Fast.h
@@ -30,12 +30,16 @@ namespace ZenLib
 class BitStream_Fast
 {
 public:
-    BitStream_Fast ()                                                           {Buffer=NULL;
-                                                                                 Buffer_Size=Buffer_Size_Init=0;
-                                                                                 BufferUnderRun=false;}
-    BitStream_Fast (const int8u* Buffer_, size_t Size_)                         {Buffer=Buffer_;
-                                                                                 Buffer_Size=Buffer_Size_Init=Size_*8; //Size is in bits
-                                                                                 BufferUnderRun=false;}
+    BitStream_Fast ()                                                           { Buffer = NULL;
+                                                                                  Buffer_Size = 0;
+                                                                                  Buffer_Size_Init = 0;
+                                                                                  LastByte = 0;
+                                                                                  BufferUnderRun = false; }
+    BitStream_Fast (const int8u* Buffer_, size_t Size_)                         { Buffer = Buffer_;
+                                                                                  Buffer_Size = Size_ * 8; //Size is in bits
+                                                                                  Buffer_Size_Init = Size_ * 8; //Size is in bits
+                                                                                  LastByte = 0;
+                                                                                  BufferUnderRun = false; }
     ~BitStream_Fast ()                                                          {}
 
     void Attach(const int8u* Buffer_, size_t Size_)

--- a/Source/ZenLib/BitStream_Fast.h
+++ b/Source/ZenLib/BitStream_Fast.h
@@ -182,11 +182,12 @@ public:
         {
             case 3 :    NewBits-=8;
                         ToReturn|=*(Buffer++)<<NewBits;
+                        [[fallthrough]];
             case 2 :    NewBits-=8;
                         ToReturn|=*(Buffer++)<<NewBits;
+                        [[fallthrough]];
             case 1 :    NewBits-=8;
                         ToReturn|=*(Buffer++)<<NewBits;
-            default:    ;
         }
         LastByte=*(Buffer++);
         Buffer_Size-=HowMany;
@@ -358,13 +359,14 @@ public:
             case 3 :    NewBits-=8;
                         ToReturn|=*Buffer<<NewBits;
                         Buffer++;
+                        [[fallthrough]];
             case 2 :    NewBits-=8;
                         ToReturn|=*Buffer<<NewBits;
                         Buffer++;
+                        [[fallthrough]];
             case 1 :    NewBits-=8;
                         ToReturn|=*Buffer<<NewBits;
                         Buffer++;
-            default:    ;
         }
         ToReturn|=((*Buffer)>>((Buffer_Size-HowMany)%8))&Mask[NewBits];
 

--- a/Source/ZenLib/BitStream_LE.h
+++ b/Source/ZenLib/BitStream_LE.h
@@ -26,16 +26,17 @@ namespace ZenLib
 class BitStream_LE : public BitStream
 {
 public:
-    BitStream_LE ()                                                             :BitStream()
-    {
-        endbyte=0;
-        endbit=0;
-        buffer=NULL;
-        ptr=NULL;
-        storage=0;
+    BitStream_LE()                                                              : BitStream(), 
+                                                                                  endbyte(0), 
+                                                                                  endbit(0), 
+                                                                                  buffer(NULL), 
+                                                                                  ptr(NULL), 
+                                                                                  ptr_BeforeLastCall(NULL), 
+                                                                                  storage(0) {
     };
 
-    BitStream_LE (const int8u* Buffer_, size_t Size_)                           :BitStream(Buffer_, Size_) {
+    BitStream_LE (const int8u* Buffer_, size_t Size_)                           : BitStream(Buffer_, Size_),
+                                                                                  ptr_BeforeLastCall(NULL) {
         Attach(Buffer_, Size_);
     };
 

--- a/Source/ZenLib/Dir.cpp
+++ b/Source/ZenLib/Dir.cpp
@@ -530,13 +530,13 @@ public:
     Dir::dirlist_t Options;
     HANDLE hFind;
     #ifdef UNICODE
-        WIN32_FIND_DATAW FindFileDataW;
+        WIN32_FIND_DATAW FindFileDataW{};
     #else
-        WIN32_FIND_DATA FindFileData;
+        WIN32_FIND_DATA FindFileData{};
     #endif //UNICODE
 
     GetAllFileNames_Private()
-        : hFind(INVALID_HANDLE_VALUE)
+        : Options(), hFind(INVALID_HANDLE_VALUE)
     {
     }
 };

--- a/Source/ZenLib/Format/Http/Http_Cookies.cpp
+++ b/Source/ZenLib/Format/Http/Http_Cookies.cpp
@@ -100,8 +100,9 @@ void Cookies::Create_Lines(std::ostream& Out)
             struct tm *Gmt=gmtime(&Cookie->second.Expires);
             #endif
 
-            if (strftime(Temp, 200, "%a, %d-%b-%Y %H:%M:%S GMT", Gmt))
-                Out << "; expires=" << Temp;
+            if (Gmt)
+                if (strftime(Temp, 200, "%a, %d-%b-%Y %H:%M:%S GMT", Gmt))
+                    Out << "; expires=" << Temp;
         }
         if (!Cookie->second.Path.empty())
         {

--- a/Source/ZenLib/InfoMap.cpp
+++ b/Source/ZenLib/InfoMap.cpp
@@ -38,14 +38,14 @@ const Ztring InfoMap_EmptyZtring_Const; //Use it when we can't return a referenc
 //---------------------------------------------------------------------------
 // Constructors
 InfoMap::InfoMap()
-: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> ()
+: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> (), Max()
 {
     Separator[0]=EOL;
     Separator[1]=__T(";");
 }
 
 InfoMap::InfoMap(const Ztring &Source)
-: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> ()
+: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> (), Max()
 {
     Separator[0]=EOL;
     Separator[1]=__T(";");
@@ -53,7 +53,7 @@ InfoMap::InfoMap(const Ztring &Source)
 }
 
 InfoMap::InfoMap(const Char *Source)
-: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> ()
+: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> (), Max()
 {
     Separator[0]=EOL;
     Separator[1]=__T(";");
@@ -62,7 +62,7 @@ InfoMap::InfoMap(const Char *Source)
 
 #ifdef _UNICODE
 InfoMap::InfoMap (const char* S)
-: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> ()
+: std::multimap<ZenLib::Ztring, ZenLib::ZtringList> (), Max()
 {
     Separator[0]=EOL;
     Separator[1]=__T(";");

--- a/Source/ZenLib/Thread.cpp
+++ b/Source/ZenLib/Thread.cpp
@@ -304,6 +304,7 @@ Thread::returnvalue Thread::ForceTerminate()
         CriticalSectionLocker CSL(C);
 
         //Terminating (not clean)
+        #pragma warning ( suppress : 6258 ) //C6258: Using TerminateThread does not allow proper thread clean up.
         TerminateThread((HANDLE)ThreadPointer, 1);
         ThreadPointer=NULL;
 

--- a/Source/ZenLib/Translation.cpp
+++ b/Source/ZenLib/Translation.cpp
@@ -34,7 +34,7 @@ namespace ZenLib
 //---------------------------------------------------------------------------
 // Constructors
 Translation::Translation()
-: std::map<ZenLib::Ztring, ZenLib::Ztring> ()
+: std::map<ZenLib::Ztring, ZenLib::Ztring> (), Max()
 {
     Separator[0]=EOL;
     Separator[1]=__T(";");

--- a/Source/ZenLib/Ztring.cpp
+++ b/Source/ZenLib/Ztring.cpp
@@ -1867,7 +1867,7 @@ int8s Ztring::To_int8s (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=Error)
+    if (Options&Ztring_Rounded && find(__T('.'))!=Error)
     {
         float80 F=To_float80();
         F-=I;
@@ -1905,7 +1905,7 @@ int8u Ztring::To_int8u (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=std::string::npos)
+    if (Options&Ztring_Rounded && find(__T('.'))!=std::string::npos)
     {
         float32 F=To_float32();
         F-=I;
@@ -1943,7 +1943,7 @@ int16s Ztring::To_int16s (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=Error)
+    if (Options&Ztring_Rounded && find(__T('.'))!=Error)
     {
         float80 F=To_float80();
         F-=I;
@@ -1981,7 +1981,7 @@ int16u Ztring::To_int16u (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=std::string::npos)
+    if (Options&Ztring_Rounded && find(__T('.'))!=std::string::npos)
     {
         float32 F=To_float32();
         F-=I;
@@ -2019,7 +2019,7 @@ int32s Ztring::To_int32s (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=Error)
+    if (Options&Ztring_Rounded && find(__T('.'))!=Error)
     {
         float80 F=To_float80();
         F-=I;
@@ -2057,7 +2057,7 @@ int32u Ztring::To_int32u (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=std::string::npos)
+    if (Options&Ztring_Rounded && find(__T('.'))!=std::string::npos)
     {
         float32 F=To_float32();
         F-=I;
@@ -2095,7 +2095,7 @@ int64s Ztring::To_int64s (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=std::string::npos)
+    if (Options&Ztring_Rounded && find(__T('.'))!=std::string::npos)
     {
         float32 F=To_float32();
         F-=I;
@@ -2133,7 +2133,7 @@ int64u Ztring::To_int64u (int8u Radix, ztring_t Options) const
     #endif
 
     //Rounded
-    if (Options==Ztring_Rounded && find(__T('.'))!=std::string::npos)
+    if (Options&Ztring_Rounded && find(__T('.'))!=std::string::npos)
     {
         float32 F=To_float32();
         F-=I;

--- a/Source/ZenLib/Ztring.cpp
+++ b/Source/ZenLib/Ztring.cpp
@@ -1654,23 +1654,23 @@ std::string Ztring::To_UTF8 () const
             case 6:
                 utf8chars[5] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x4000000;
-                /* fallthrough */
+                [[fallthrough]];
             case 5:
                 utf8chars[4] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x200000;
-                /* fallthrough */
+                [[fallthrough]];
             case 4:
                 utf8chars[3] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x10000;
-                /* fallthrough */
+                [[fallthrough]];
             case 3:
                 utf8chars[2] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0x800;
-                /* fallthrough */
+                [[fallthrough]];
             case 2:
                 utf8chars[1] = 0x80 | (wc & 0x3f);
                 wc = (wc >> 6) | 0xc0;
-                /* fallthrough */
+                [[fallthrough]];
             case 1:
                 utf8chars[0] = (char) wc;
             }

--- a/Source/ZenLib/ZtringList.cpp
+++ b/Source/ZenLib/ZtringList.cpp
@@ -39,7 +39,7 @@ extern Ztring EmptyZtring;
 //---------------------------------------------------------------------------
 // Constructors
 ZtringList::ZtringList ()
-: std::vector<ZenLib::Ztring, std::allocator<ZenLib::Ztring> > ()
+: std::vector<ZenLib::Ztring, std::allocator<ZenLib::Ztring> > (), Max()
 {
     Separator[0]=__T(";");
     Quote=__T("\"");
@@ -47,7 +47,7 @@ ZtringList::ZtringList ()
 }
 
 ZtringList::ZtringList(const ZtringList &Source)
-: std::vector<ZenLib::Ztring, std::allocator<ZenLib::Ztring> > ()
+: std::vector<ZenLib::Ztring, std::allocator<ZenLib::Ztring> > (), Max()
 {
     Separator[0]=Source.Separator[0];
     Quote=Source.Quote;


### PR DESCRIPTION
Resolve warnings from Visual Studio Code analysis as well as set C++20 standard and Level 3 warnings for MSVC2022 project since it can now build with zero warnings using these settings.

Resolved warnings:
```
Severity	Code	Description	Project	File	Line	Suppression State	Details
Warning	C26495	Variable 'ZenLib::GetAllFileNames_Private::FindFileDataW' is uninitialized. Always initialize a member variable (type.6).	ZenLib	Dir.cpp	538		
Warning	C26495	Variable 'ZenLib::GetAllFileNames_Private::Options' is uninitialized. Always initialize a member variable (type.6).	ZenLib	Dir.cpp	538		
Warning	C6387	'Gmt' could be '0':  this does not adhere to the specification for the function 'strftime'. 	ZenLib	Format\Http\Http_Cookies.cpp	103		
Warning	C26495	Variable 'ZenLib::InfoMap::Max' is uninitialized. Always initialize a member variable (type.6).	ZenLib	InfoMap.cpp	40		
Warning	C6258	Using TerminateThread does not allow proper thread clean up.	ZenLib	Thread.cpp	307		
Warning	C26495	Variable 'ZenLib::Translation::Max' is uninitialized. Always initialize a member variable (type.6).	ZenLib	Translation.cpp	36		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	ZenLib	Ztring.cpp	1658		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	ZenLib	Ztring.cpp	1662		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	ZenLib	Ztring.cpp	1666		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	ZenLib	Ztring.cpp	1670		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	ZenLib	Ztring.cpp	1674		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	1870		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	1908		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	1946		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	1984		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	2022		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	2060		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	2098		
Warning	C26813	Use 'bitwise and' to check if a flag is set.	ZenLib	Ztring.cpp	2136		
Warning	C26495	Variable 'ZenLib::ZtringList::Max' is uninitialized. Always initialize a member variable (type.6).	ZenLib	ZtringList.cpp	49		
Warning	C26495	Variable 'ZenLib::BitStream::BufferUnderRun_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	33		
Warning	C26495	Variable 'ZenLib::BitStream::Buffer_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	33		
Warning	C26495	Variable 'ZenLib::BitStream::Buffer_Size_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	33		
Warning	C26495	Variable 'ZenLib::BitStream::LastByte' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	33		
Warning	C26495	Variable 'ZenLib::BitStream::LastByte_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	33		
Warning	C26495	Variable 'ZenLib::BitStream::LastByte_Size_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	33		
Warning	C26495	Variable 'ZenLib::BitStream::BufferUnderRun_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	38		
Warning	C26495	Variable 'ZenLib::BitStream::Buffer_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	38		
Warning	C26495	Variable 'ZenLib::BitStream::Buffer_Size_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	38		
Warning	C26495	Variable 'ZenLib::BitStream::LastByte' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	38		
Warning	C26495	Variable 'ZenLib::BitStream::LastByte_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	38		
Warning	C26495	Variable 'ZenLib::BitStream::LastByte_Size_BookMark' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream.h	38		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream.h	101		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream.h	105		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream.h	109		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream.h	194		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream.h	197		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream.h	200		
Warning	C26495	Variable 'ZenLib::BitStream_Fast::LastByte' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream_Fast.h	33		
Warning	C26495	Variable 'ZenLib::BitStream_Fast::LastByte' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream_Fast.h	36		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream_Fast.h	185		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream_Fast.h	187		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream_Fast.h	191		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream_Fast.h	361		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream_Fast.h	364		
Warning	C26819	Unannotated fallthrough between switch labels (es.78).	MediaInfoLib	BitStream_Fast.h	369		
Warning	C26495	Variable 'ZenLib::BitStream_LE::ptr_BeforeLastCall' is uninitialized. Always initialize a member variable (type.6).	MediaInfoLib	BitStream_LE.h	29		
```
