### PR TITLE
Bump CMake min version to 3.5

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(ZenLib)
 


### PR DESCRIPTION
In order to have CMake 4.0 working without option

Partially fix https://github.com/MediaArea/MediaInfoLib/issues/2242.