### PR TITLE
Fix source files deleted by clean on Windows

### DIFF
--- a/Project/CMake/CMakeLists.txt
+++ b/Project/CMake/CMakeLists.txt
@@ -111,7 +111,7 @@ set(ZenLib_SRCS
   ${ZenLib_SOURCES_PATH}/ZenLib/Format/Http/Http_Utils.cpp
   )
 
-if(WIN32)
+if(MINGW)
   set_source_files_properties(${ZenLib_SRCS} ${ZenLib_HDRS} ${ZenLib_format_html_HDRS} ${ZenLib_format_http_HDRS}
     PROPERTIES GENERATED true)
 endif()


### PR DESCRIPTION
Was trying out CMake on Windows MSVC and surprised that all ZenLib cpp source files were deleted after executing clean.