### PR TITLE
Bitstream: Prevent array overreads and undefined behaviour

### DIFF
--- a/Source/ZenLib/BitStream_Fast.h
+++ b/Source/ZenLib/BitStream_Fast.h
@@ -80,6 +80,9 @@ public:
             0x1f, 0x3f, 0x7f, 0xff,
         };
 
+        if (HowMany==0 || HowMany>8)
+            return 0;
+
         if (HowMany<=(Buffer_Size%8))
         {
             Buffer_Size-=HowMany;
@@ -116,6 +119,9 @@ public:
             0x01ff, 0x03ff, 0x07ff, 0x0fff,
             0x1fff, 0x3fff, 0x7fff, 0xffff,
         };
+
+        if (HowMany==0 || HowMany>16)
+            return 0;
 
         if (HowMany<=(Buffer_Size%8))
         {
@@ -163,6 +169,9 @@ public:
             0x01ffffff, 0x03ffffff, 0x07ffffff, 0x0fffffff,
             0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff,
         };
+
+        if (HowMany==0 || HowMany>32)
+            return 0;
 
         if (HowMany<=(Buffer_Size%8))
         {
@@ -263,6 +272,9 @@ public:
             0x1f, 0x3f, 0x7f, 0xff,
         };
 
+        if (HowMany==0 || HowMany>8)
+            return 0;
+
         if (HowMany<=(Buffer_Size%8))
             return (LastByte>>((Buffer_Size-HowMany)%8))&Mask[HowMany];
 
@@ -294,6 +306,9 @@ public:
             0x01ff, 0x03ff, 0x07ff, 0x0fff,
             0x1fff, 0x3fff, 0x7fff, 0xffff,
         };
+
+        if (HowMany==0 || HowMany>16)
+            return 0;
 
         if (HowMany<=(Buffer_Size%8))
             return (LastByte>>((Buffer_Size-HowMany)%8))&Mask[HowMany];
@@ -340,6 +355,9 @@ public:
             0x01ffffff, 0x03ffffff, 0x07ffffff, 0x0fffffff,
             0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff,
         };
+
+        if (HowMany==0 || HowMany>32)
+            return 0;
 
         if (HowMany<=(Buffer_Size%8))
             return (LastByte>>((Buffer_Size-HowMany)%8))&Mask[HowMany];

--- a/Source/ZenLib/BitStream_LE.h
+++ b/Source/ZenLib/BitStream_LE.h
@@ -65,6 +65,10 @@ public:
           0x01ffffff, 0x03ffffff, 0x07ffffff, 0x0fffffff,
           0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff,
         };
+
+        if (HowMany==0 || HowMany>32)
+            return 0;
+
         unsigned long m=Mask[HowMany];
 
         HowMany+=endbit;
@@ -103,6 +107,18 @@ public:
 
     void Skip(size_t bits)
     {
+        if (bits==0)
+            return;
+        if (bits>32) //Get is only for <=32 bits
+        {
+            do {
+                Get(32);
+                bits-=32;
+            } while (bits>32);
+            if (bits)
+                Get(bits);
+            return;
+        }
         Get(bits);
     }
 

--- a/Source/ZenLib/BitStream_LE.h
+++ b/Source/ZenLib/BitStream_LE.h
@@ -130,7 +130,7 @@ public:
     void Byte_Align()
     {
         if (endbit)
-            Get(endbit);
+            Get(8-endbit);
     };
 
     size_t Offset_Get()


### PR DESCRIPTION
Attempt to fix #196 as well as reduce MediaInfoLib crashes.